### PR TITLE
Replace deprecated Models usage with Generators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ An example of how to specify such models is provided in the snippet below:
 ```python
 ...
     GenerationStep(
-        model=Models.BOTORCH_MODULAR,
+        model=Generators.BOTORCH_MODULAR,
         num_trials=-1,
         max_parallelism=3,
         model_kwargs={"botorch_acqf_class": qKnowledgeGradient},

--- a/benchmark_assignment.py
+++ b/benchmark_assignment.py
@@ -18,8 +18,8 @@ set_seeds()  # setting the random seed for reproducibility
 
 import numpy as np
 from ax.service.ax_client import AxClient, ObjectiveProperties
-from ax.modelbridge.factory import Models
-from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.factory import Generators
+from ax.generation_strategy.generation_strategy import GenerationStep, GenerationStrategy
 from botorch.acquisition import ExpectedImprovement
 
 seed_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -42,8 +42,8 @@ for seed in seed_list:
 # --------------------------------------------------------------------------------------
 import numpy as np
 from ax.service.ax_client import AxClient, ObjectiveProperties
-from ax.modelbridge.factory import Models
-from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.factory import Generators
+from ax.generation_strategy.generation_strategy import GenerationStep, GenerationStrategy
 from botorch.acquisition import UpperConfidenceBound
 
 seed_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -81,8 +81,8 @@ import matplotlib.pyplot as plt
 
 import numpy as np
 from ax.service.ax_client import AxClient, ObjectiveProperties
-from ax.modelbridge.factory import Models
-from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
+from ax.modelbridge.factory import Generators
+from ax.generation_strategy.generation_strategy import GenerationStep, GenerationStrategy
 from botorch.acquisition import LogExpectedImprovement
 
 seed_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
- Replaced deprecated `Models` with `Generators` .
